### PR TITLE
Use current time to update latest stock list info from official sites

### DIFF
--- a/grs/twseopen.py
+++ b/grs/twseopen.py
@@ -49,7 +49,7 @@ class TWSEOpen(object):
             pass
         return self.caldata(time)
 
-    def latest_open_day(self, latest_open, backward_check=True):
+    def recent_open_day(self, latest_open, backward_check=True):
         ''' 尋找離指定日期(包含當天)最近一天有開市的日期
 
             :param datetime latest_open: 指定日期

--- a/tools/make_otc_list.py
+++ b/tools/make_otc_list.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from grs import TWSEOpen
 
 
-NOW = TWSEOpen().latest_open_day(datetime.now())
+NOW = TWSEOpen().recent_open_day(datetime.now())
 SAVEPATH = '../grs/otc_list.csv'
 INDUSTRYCODE = '../grs/industry_code_otc.csv'
 

--- a/tools/make_twse_list.py
+++ b/tools/make_twse_list.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from grs import TWSEOpen
 
 
-NOW = TWSEOpen().latest_open_day(datetime.now())
+NOW = TWSEOpen().recent_open_day(datetime.now())
 SAVEPATH = '../grs/twse_list.csv'
 INDUSTRYCODE = '../grs/industry_code.csv'
 


### PR DESCRIPTION
I think it would be more convenient and make more sense to use the current time rather than a hard-coded past time for generating csv files of the latest stock info, that's the main reason I made those changes :p
