### PR TITLE
Fixed diff in realtime2.py : should divide yesterday_price not open

### DIFF
--- a/grs/realtime2.py
+++ b/grs/realtime2.py
@@ -104,8 +104,8 @@ class Realtime(object):
             data[i['c']]['volume_acc'] = float(i['v'])
             data[i['c']]['yesterday_price'] = float(i['y'])
 
-            diff = data[i['c']]['price'] - data[i['c']]['open']
-            diff_percent = round(diff / data[i['c']]['open'] * 100, 2)
+            diff = data[i['c']]['price'] - data[i['c']]['yesterday_price']
+            diff_percent = round(diff / data[i['c']]['yesterday_price'] * 100, 2)
             data[i['c']]['diff'] = (round(diff, 2), diff_percent)
 
             data[i['c']]['info'] = {'name': i['n'],


### PR DESCRIPTION
yesterday price minus realtime price is the diff price.
漲跌價應為即時價錢減去昨天收盤價


